### PR TITLE
Append trailing slash to xhttp path only when placement needs it

### DIFF
--- a/option/v2ray_transport.go
+++ b/option/v2ray_transport.go
@@ -311,8 +311,11 @@ func (c *V2RayXHTTPBaseOptions) GetNormalizedPath() string {
 	if path == "" || path[0] != '/' {
 		path = "/" + path
 	}
-	if path[len(path)-1] != '/' {
-		path = path + "/"
+	if c.GetNormalizedSessionPlacement() == PlacementPath ||
+		c.GetNormalizedSeqPlacement() == PlacementPath {
+		if path[len(path)-1] != '/' {
+			path = path + "/"
+		}
 	}
 	return path
 }


### PR DESCRIPTION
GetNormalizedPath() unconditionally appended a trailing slash to the configured path. That extra segment is only meaningful when session or seq data is carried in the path.